### PR TITLE
[feat/fix/design] 지도 수정 구현, 커스텀컨펌창 action add/edit 모두 적용, 디자인, 포인트모달props명 변경

### DIFF
--- a/app/_api/individualAction-edit/edit-api.ts
+++ b/app/_api/individualAction-edit/edit-api.ts
@@ -5,6 +5,7 @@ import type {
   FormDataType,
   InsertImgUrls,
 } from "@/app/_types/individualAction-add/individualAction-add";
+import { placeCoordinateType } from "@/app/_types/individualAction-detail/individualAction-detail";
 
 // 수정할 action_id의 데이터 가져오기
 // (외래키 연결된 green_action_images 테이블에서 이미지 url도 함께 가져오기)
@@ -32,9 +33,13 @@ type FormDataWithoutUid = Omit<FormDataType, "user_uid">;
 export const updateActionTextForm = async ({
   action_id,
   formData,
+  activityLocation,
+  activityLocationMap,
 }: {
   action_id: string;
   formData: FormData;
+  activityLocation: string;
+  activityLocationMap: placeCoordinateType | null;
 }) => {
   try {
     // 업데이트할 텍스트 데이터
@@ -43,8 +48,8 @@ export const updateActionTextForm = async ({
       content: String(formData.get("activityDescription")),
       start_date: String(formData.get("startDate")),
       end_date: String(formData.get("endDate")),
-      location: String(formData.get("activityLocation")),
-      location_map: null, // 추후 수정 예정
+      location: activityLocation,
+      location_map: activityLocationMap,
       recruit_number: Number(formData.get("maxParticipants")),
       kakao_link: String(formData.get("openKakaoLink")),
     };

--- a/app/_api/individualAction-edit/edit-api.ts
+++ b/app/_api/individualAction-edit/edit-api.ts
@@ -5,7 +5,7 @@ import type {
   FormDataType,
   InsertImgUrls,
 } from "@/app/_types/individualAction-add/individualAction-add";
-import { placeCoordinateType } from "@/app/_types/individualAction-detail/individualAction-detail";
+import type { placeCoordinateType } from "@/app/_types/individualAction-detail/individualAction-detail";
 
 // 수정할 action_id의 데이터 가져오기
 // (외래키 연결된 green_action_images 테이블에서 이미지 url도 함께 가져오기)

--- a/app/_components/community/AddComment.tsx
+++ b/app/_components/community/AddComment.tsx
@@ -100,7 +100,7 @@ const AddComment = ({ loggedInUserUid, post_id }: AddCommentProps) => {
       {showPointModal && (
         <PointModal
           isOpen={showPointModal}
-          onClose={() => setShowPointModal(false)}
+          onCloseFn={() => setShowPointModal(false)}
           point={100}
         />
       )}

--- a/app/_components/community/AddPostModal.tsx
+++ b/app/_components/community/AddPostModal.tsx
@@ -259,7 +259,7 @@ const AddPostModal = () => {
       {showPointModal && (
         <PointModal
           isOpen={showPointModal}
-          onClose={() => setShowPointModal(false)}
+          onCloseFn={() => setShowPointModal(false)}
           point={300}
         />
       )}

--- a/app/_components/community/PointModal.tsx
+++ b/app/_components/community/PointModal.tsx
@@ -29,7 +29,7 @@ const PointModal: React.FC<PointModalProps> = ({
         placement="center"
         isOpen={open ?? isOpen}
         onOpenChange={onClose ?? onOpenChange}
-        onClose={handleClick || onCloseFn} // onClose로 처리함으로써 close 버튼 외 모달바깥을 눌러 모달이 꺼져도 handleClick을 작동시킴
+        onClose={mod === "add" ? handleClick : onCloseFn} // onClose로 처리함으로써 close 버튼 외 모달바깥을 눌러 모달이 꺼져도 handleClick을 작동시킴
       >
         <ModalContent>
           {(onClose) => (

--- a/app/_components/community/PointModal.tsx
+++ b/app/_components/community/PointModal.tsx
@@ -16,12 +16,12 @@ import type { PointModalProps } from "@/app/_types/point/point";
 
 const PointModal: React.FC<PointModalProps> = ({
   isOpen: open,
-  onClose,
+  onCloseFn,
   point,
   mod,
   handleClick,
 }) => {
-  const { isOpen, onOpenChange } = useDisclosure();
+  const { isOpen, onClose, onOpenChange } = useDisclosure();
 
   return (
     <>
@@ -29,6 +29,7 @@ const PointModal: React.FC<PointModalProps> = ({
         placement="center"
         isOpen={open ?? isOpen}
         onOpenChange={onClose ?? onOpenChange}
+        onClose={handleClick || onCloseFn} // onClose로 처리함으로써 close 버튼 외 모달바깥을 눌러 모달이 꺼져도 handleClick을 작동시킴
       >
         <ModalContent>
           {(onClose) => (

--- a/app/_components/customConfirm/CustomConfirm.tsx
+++ b/app/_components/customConfirm/CustomConfirm.tsx
@@ -139,14 +139,25 @@ const CustomConfirm: React.FC<CustomConfirmProps> = ({
           {text}
         </div>
         <div className="text-center bg-[#f5f5f2] flex flex-row gap-3 justify-center py-5 rounded-xl">
-          <Button
-            type="submit"
-            form={`${mode === "individualAdd" && "mainForm"}`}
-            onClick={customConfirm.okay}
-            className="inline-block w-[100px] py-[5px]  cursor-pointer border border-[#999] bg-white hover:bg-black hover:text-white"
-          >
-            네
-          </Button>
+          {/* mode === 'individualAdd' 인 경우 (action 생성/수정 페이지) form 속성 추가 / form = {``} 속성 안에서 조건을 줄 시 없는 경우 문제가 생김 */}
+          {mode === "individualAdd" ? (
+            <Button
+              type="submit"
+              form="mainForm"
+              onClick={customConfirm.okay}
+              className="inline-block w-[100px] py-[5px]  cursor-pointer border border-[#999] bg-white hover:bg-black hover:text-white"
+            >
+              네
+            </Button>
+          ) : (
+            <Button
+              type="submit"
+              onClick={customConfirm.okay}
+              className="inline-block w-[100px] py-[5px]  cursor-pointer border border-[#999] bg-white hover:bg-black hover:text-white"
+            >
+              네
+            </Button>
+          )}
           <Button
             onClick={customConfirm.close}
             className="inline-block w-[100px] py-[5px]  cursor-pointer border border-[#999] bg-white hover:bg-black hover:text-white"

--- a/app/_components/customConfirm/CustomConfirm.tsx
+++ b/app/_components/customConfirm/CustomConfirm.tsx
@@ -92,8 +92,9 @@ const CustomConfirm: React.FC<CustomConfirmProps> = ({
       ) : (
         mode !== "community" && (
           <Button
-            variant="ghost"
-            className="text-gray-500 rounded-full !w-[140px] h-[33px] border border-gray-400 bg-[#EFEFEF]"
+            className="rounded-full !w-[170px] h-[40px] border-1.5 border-gray-300 text-sm text-gray-500 font-extrabold hover:bg-black hover:text-white"
+            // border border-gray-400 bg-[#EFEFEF]
+            // variant="ghost"
             onClick={() => {
               customConfirm.show(handleClick);
             }}
@@ -140,6 +141,7 @@ const CustomConfirm: React.FC<CustomConfirmProps> = ({
         <div className="text-center bg-[#f5f5f2] flex flex-row gap-3 justify-center py-5 rounded-xl">
           <Button
             type="submit"
+            form={`${mode === "individualAdd" && "mainForm"}`}
             onClick={customConfirm.okay}
             className="inline-block w-[100px] py-[5px]  cursor-pointer border border-[#999] bg-white hover:bg-black hover:text-white"
           >

--- a/app/_types/point/point.ts
+++ b/app/_types/point/point.ts
@@ -1,6 +1,6 @@
 export interface PointModalProps {
   isOpen?: boolean | null;
-  onClose?: () => void;
+  onCloseFn?: () => void;
   point: number;
   mod?: string;
   handleClick?: () => void;

--- a/app/individualAction/add/page.tsx
+++ b/app/individualAction/add/page.tsx
@@ -114,6 +114,7 @@ const AddActionPage = () => {
       setUploadedFileUrls([]);
       setActivityLocation("");
       setActivityLocationMap("");
+      locationMapRef.current = null;
 
       // router.push(`/individualAction`); // 그냥 이동시키면 modal창 제대로 확인하기 전에 이동됨 / but 모달창 x나 close해야만 이동하는 것도 문제
     } catch (error) {
@@ -259,7 +260,9 @@ const AddActionPage = () => {
           isOpen={Modal.showPoint}
           point={300}
           mod={"add"}
-          onClose={() => setModal((state) => ({ ...state, showPoint: false }))}
+          onCloseFn={() =>
+            setModal((state) => ({ ...state, showPoint: false }))
+          } // 여기서는 onCloseFn 필요가 없음
           handleClick={() => {
             router.push(`/individualAction/detail/${actionId}`);
           }}

--- a/app/individualAction/add/page.tsx
+++ b/app/individualAction/add/page.tsx
@@ -81,46 +81,41 @@ const AddActionPage = () => {
     }
 
     try {
-      // 확인창 표시 - 커스텀컨펌 사용 시 X (우선 컨펌창으로)
-      if (window.confirm("등록하시겠습니까?")) {
-        // 1. user_uid와 텍스트 formData insert -> action_id 반환받기
-        const activityLocationMap = locationMapRef.current || null; // location 좌표
-        // const allActivityLocation = activityLocationMap
-        //   ? `${activityLocation} (${activityLocationMap})`
-        //   : activityLocation;
+      // 1. user_uid와 텍스트 formData insert -> action_id 반환받기
+      const activityLocationMap = locationMapRef.current || null; // 지도 장소정보 - 장소 좌표, 장소명, 장소 id
+      // const allActivityLocation = activityLocationMap
+      //   ? `${activityLocation} (${activityLocationMap})`
+      //   : activityLocation;
 
-        const action_id = await insertActionTextForm({
-          formData,
-          activityLocation,
-          activityLocationMap,
-          loggedInUserUid,
-        });
-        setActionId(action_id);
-        // 2. 500point 업데이트
-        await updateUserPoint(loggedInUserUid, { mode: "addAction" });
+      const action_id = await insertActionTextForm({
+        formData,
+        activityLocation,
+        activityLocationMap,
+        loggedInUserUid,
+      });
+      setActionId(action_id);
+      // 2. 500point 업데이트
+      await updateUserPoint(loggedInUserUid, { mode: "addAction" });
 
-        // 3. 이미지 스토리지에 저장하기 + 이미지 url 배열 반환받기
-        const imgUrlsArray = await uploadFilesAndGetUrls({ files, action_id });
+      // 3. 이미지 스토리지에 저장하기 + 이미지 url 배열 반환받기
+      const imgUrlsArray = await uploadFilesAndGetUrls({ files, action_id });
 
-        // 4. 이미지url들 table에 넣기 - action_id에 id사용
-        await insertImgUrls({ action_id, imgUrlsArray });
+      // 4. 이미지url들 table에 넣기 - action_id에 id사용
+      await insertImgUrls({ action_id, imgUrlsArray });
 
-        // 5. 단체 채팅방 생성
-        await insertGroupChatRoom({ loggedInUserUid, action_id });
+      // 5. 단체 채팅방 생성
+      await insertGroupChatRoom({ loggedInUserUid, action_id });
 
-        setModal((state) => ({ ...state, showPoint: true })); // 포인트 휙득 모달창
+      setModal((state) => ({ ...state, showPoint: true })); // 포인트 휙득 모달창
 
-        // 입력값 초기화 - 혹은 그냥 바로 green action list 페이지로 이동시키기
-        const target = event.target as HTMLFormElement;
-        target.reset();
-        setUploadedFileUrls([]);
-        setActivityLocation("");
-        setActivityLocationMap("");
+      // 입력값 초기화 - 혹은 그냥 바로 green action list 페이지로 이동시키기
+      const target = event.target as HTMLFormElement;
+      target.reset();
+      setUploadedFileUrls([]);
+      setActivityLocation("");
+      setActivityLocationMap("");
 
-        // router.push(`/individualAction`); // 그냥 이동시키면 modal창 제대로 확인하기 전에 이동됨 / but 모달창 x나 close해야만 이동하는 것도 문제
-      } else {
-        return;
-      }
+      // router.push(`/individualAction`); // 그냥 이동시키면 modal창 제대로 확인하기 전에 이동됨 / but 모달창 x나 close해야만 이동하는 것도 문제
     } catch (error) {
       console.error("Error inserting data:", error);
     }
@@ -216,13 +211,19 @@ const AddActionPage = () => {
           {/* 등록, 취소 버튼 */}
           {(isDesktop || isLaptop) && (
             <div className="w-[724px] flex justify-center gap-4">
-              <button
+              {/* <button
                 type="submit"
                 form="mainForm"
                 className="bg-gray-200 w-[170px] h-[40px] rounded-full border-1.5 border-gray-300 text-sm font-medium text-gray-500"
               >
                 <span className="font-extrabold">등록완료</span>
-              </button>
+              </button> */}
+              <CustomConfirm
+                text="등록하시겠습니까?"
+                buttonName="등록완료"
+                okFunction={() => handleSubmit}
+                mode="individualAdd"
+              />
               <button
                 onClick={handleCancelPost}
                 className="bg-gray-100 w-[170px] h-[40px] rounded-full border-1.5 border-gray-300 text-sm font-medium text-gray-500"
@@ -234,13 +235,20 @@ const AddActionPage = () => {
 
           {isMobile && (
             <div className="w-[291px] flex justify-center gap-4 mt-3">
-              <button
+              {/* 커스텀컨펌창으로 다시 변경 */}
+              <CustomConfirm
+                text="등록하시겠습니까?"
+                buttonName="등록완료"
+                okFunction={() => handleSubmit}
+                mode="individualAdd"
+              />
+              {/* <button
                 type="submit"
                 form="mainForm"
                 className="bg-black w-[170px] h-[40px] rounded-full border-1.5  text-sm font-medium text-white"
               >
                 <span className="font-extrabold">등록완료</span>
-              </button>
+              </button> */}
             </div>
           )}
         </div>

--- a/app/individualAction/detail/[id]/page.tsx
+++ b/app/individualAction/detail/[id]/page.tsx
@@ -238,7 +238,7 @@ const DetailPage = () => {
                           alt="위치 아이콘"
                           className="float-left mr-[15px] size-[20.26px]"
                         />
-                        <p className="float-left mr-8 font-semibold text-[11px] text-[#848484]">
+                        <p className="float-left mr-7 font-semibold text-[11px] text-[#848484] w-[25px]">
                           장소
                         </p>
                         <p className="font-semibold text-[13px] text-[#1e1e1e]">
@@ -452,7 +452,7 @@ const DetailPage = () => {
                           alt="위치 아이콘"
                           className="float-left mr-[15px] size-[20.26px]"
                         />
-                        <p className="float-left mr-8 font-semibold text-[11px] text-[#848484]">
+                        <p className="float-left mr-7 font-semibold text-[11px] text-[#848484] w-[25px]">
                           장소
                         </p>
                         <p className="font-semibold text-[13px] text-[#1e1e1e]">
@@ -606,7 +606,7 @@ const DetailPage = () => {
                             alt="위치 아이콘"
                             className="float-left mr-[15px] size-[20.26px]"
                           />
-                          <p className="float-left mr-8 font-semibold text-[11px] text-[#848484]">
+                          <p className="float-left mr-7 font-semibold text-[11px] text-[#848484] w-[25px]">
                             장소
                           </p>
                           <p className="font-semibold text-[13px] text-[#1e1e1e]">

--- a/app/individualAction/edit/[id]/page.tsx
+++ b/app/individualAction/edit/[id]/page.tsx
@@ -51,6 +51,7 @@ const EditActionPage = ({ params }: { params: { id: string } }) => {
       setUploadedFileUrls(idsAndUrlsObjArray);
       setActivityLocation(originalActionData.location || "");
       setActivityLocationMap(originalActionData.location_map?.placeName || "");
+      locationMapRef.current = originalActionData.location_map;
     }
   }, [originalActionData]);
 
@@ -93,10 +94,13 @@ const EditActionPage = ({ params }: { params: { id: string } }) => {
     const formData = new FormData(event.currentTarget);
 
     try {
+      const activityLocationMap = locationMapRef.current;
       // 1. action_id와 텍스트 formData 보내서 update
       await updateActionTextForm({
         action_id,
         formData,
+        activityLocation,
+        activityLocationMap,
       });
 
       // 2. 이미지 스토리지에 저장하기 + 이미지 url 배열 반환받기
@@ -409,9 +413,9 @@ const EditActionPage = ({ params }: { params: { id: string } }) => {
                   </div>
                 </div>
                 {/* 지도 검색으로 장소선택 시 뜨게 할 지도(미리보기) */}
-                {originalActionData?.location_map && (
+                {locationMapRef.current && (
                   <div className="w-[310px] h-[220px] mt-[41px]">
-                    <KakaoMap placeInfo={originalActionData?.location_map} />
+                    <KakaoMap placeInfo={locationMapRef.current} />
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] 이걸 계속 복사해서 사용해주세요!

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
[[fix] 포인트모달 onClose -> onCloseFn으로  props 키 이름변경 
(모달 바깥눌러 닫을 시에도 처리해주기위해, onClose 속성을 가져오다보니 이름이 중첩되어 바꿨습니다) 

커스텀컨펌창 문제도 모두 해결해 개인액션 add,edit 페이지에 모두 적용해놨습니다.
이 과정에서 커스텀컨펌 컴포넌트에 form 속성을 주면서 에러가 잠시 생겼었는데 해결했습니다

```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
```
## 📸 스크린샷(선택)
```
|기능|스크린샷|
<!-- 기능을 gif로 만들어서 올려주세요 -->
[GIF]<img src = "" width="250">|
```
## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
